### PR TITLE
add motor selector component to reduce repetition

### DIFF
--- a/src/web/calculators/arm/components/ArmCalculator.tsx
+++ b/src/web/calculators/arm/components/ArmCalculator.tsx
@@ -2,12 +2,7 @@ import Graph from "common/components/graphing/Graph";
 import { GraphConfig } from "common/components/graphing/graphConfig";
 import SimpleHeading from "common/components/heading/SimpleHeading";
 import SingleInputLine from "common/components/io/inputs/SingleInputLine";
-import {
-  MeasurementInput,
-  MotorInput,
-  NumberInput,
-  RatioInput,
-} from "common/components/io/new/inputs";
+import { MeasurementInput, NumberInput } from "common/components/io/new/inputs";
 import MeasurementOutput from "common/components/io/outputs/MeasurementOutput";
 import { Column, Columns, Message } from "common/components/styling/Building";
 import { useAsyncMemo } from "common/hooks/useAsyncMemo";
@@ -18,6 +13,7 @@ import { armGraphConfig, ArmParamsV1, ArmStateV1 } from "web/calculators/arm";
 import { MomentaryArmState } from "web/calculators/arm/armMath";
 import { ArmState } from "web/calculators/arm/converter";
 import KgKvKaDisplay from "web/calculators/shared/components/KgKvKaDisplay";
+import MotorSelector from "web/calculators/shared/components/MotorSelector";
 import {
   calculateKa,
   calculateKg,
@@ -124,36 +120,7 @@ export default function ArmCalculator(): JSX.Element {
 
       <Columns>
         <Column>
-          <SingleInputLine
-            label="Motor"
-            id="motor"
-            tooltip="Motors powering the arm."
-          >
-            <MotorInput stateHook={[get.motor, set.setMotor]} />
-          </SingleInputLine>
-          <SingleInputLine
-            label="Ratio"
-            id="ratio"
-            tooltip="Ratio of the gearbox."
-          >
-            <RatioInput stateHook={[get.ratio, set.setRatio]} />
-          </SingleInputLine>
-          <SingleInputLine
-            label="Efficiency (%)"
-            id="efficiency"
-            tooltip="The efficiency of the system in transmitting torque from the motors."
-          >
-            <NumberInput stateHook={[get.efficiency, set.setEfficiency]} />
-          </SingleInputLine>
-          <SingleInputLine
-            label="Current Limit"
-            id="currentLimit"
-            tooltip="Current limit applied to each motor."
-          >
-            <MeasurementInput
-              stateHook={[get.currentLimit, set.setCurrentLimit]}
-            />
-          </SingleInputLine>
+          <MotorSelector get={get} set={set} />
           <SingleInputLine
             label="CoM Distance"
             id="comLength"

--- a/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
+++ b/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
@@ -27,6 +27,7 @@ import {
 } from "web/calculators/flywheel/flywheelMath";
 import KvKaDisplay from "web/calculators/shared/components/KvKaDisplay";
 import { calculateKa, calculateKv } from "web/calculators/shared/sharedMath";
+import MotorSelector from "web/calculators/shared/components/MotorSelector";
 
 export default function FlywheelCalculator(): JSX.Element {
   const [get, set] = useGettersSetters(
@@ -45,13 +46,13 @@ export default function FlywheelCalculator(): JSX.Element {
         ),
         get.motor,
         get.currentLimit,
-        get.motorRatio,
+        get.ratio,
         get.shooterTargetSpeed
       ),
     [
       get.motor,
       get.currentLimit,
-      get.motorRatio,
+      get.ratio,
       get.shooterTargetSpeed,
       get.shooterMomentOfInertia,
       get.flywheelMomentOfInertia,
@@ -61,10 +62,10 @@ export default function FlywheelCalculator(): JSX.Element {
 
   const shooterTopSpeed = useMemo(
     () =>
-      get.motorRatio.asNumber() === 0
+      get.ratio.asNumber() === 0
         ? new Measurement(0, "rpm")
-        : get.motor.freeSpeed.div(get.motorRatio.asNumber()),
-    [get.motorRatio, get.motor.freeSpeed]
+        : get.motor.freeSpeed.div(get.ratio.asNumber()),
+    [get.ratio, get.motor.freeSpeed]
   );
 
   const shooterSurfaceSpeed = useMemo(
@@ -164,7 +165,7 @@ export default function FlywheelCalculator(): JSX.Element {
       calculateRecoveryTime(
         totalMomentOfInertia,
         get.motor,
-        get.motorRatio,
+        get.ratio,
         1 / 100,
         get.shooterTargetSpeed,
         speedAfterShot,
@@ -173,7 +174,7 @@ export default function FlywheelCalculator(): JSX.Element {
     [
       totalMomentOfInertia,
       get.motor,
-      get.motorRatio,
+      get.ratio,
       get.shooterTargetSpeed,
       speedAfterShot,
       get.currentLimit,
@@ -183,10 +184,10 @@ export default function FlywheelCalculator(): JSX.Element {
   const kV = useMemo(
     () =>
       calculateKv(
-        get.motor.freeSpeed.div(get.motorRatio.asNumber()),
+        get.motor.freeSpeed.div(get.ratio.asNumber()),
         get.flywheelRadius
       ),
-    [get.motor.freeSpeed, get.motorRatio, get.flywheelRadius]
+    [get.motor.freeSpeed, get.ratio, get.flywheelRadius]
   );
 
   const kA = useMemo(
@@ -194,7 +195,7 @@ export default function FlywheelCalculator(): JSX.Element {
       calculateKa(
         get.motor.stallTorque
           .mul(get.motor.quantity)
-          .mul(get.motorRatio.asNumber())
+          .mul(get.ratio.asNumber())
           .mul(get.efficiency / 100),
         get.flywheelRadius,
         totalMomentOfInertia.div(get.flywheelRadius.mul(get.flywheelRadius))
@@ -202,7 +203,7 @@ export default function FlywheelCalculator(): JSX.Element {
     [
       get.motor.stallTorque,
       get.motor.quantity,
-      get.motorRatio,
+      get.ratio,
       get.efficiency,
       get.flywheelRadius,
       totalMomentOfInertia,
@@ -243,20 +244,7 @@ export default function FlywheelCalculator(): JSX.Element {
       />
       <Columns multiline>
         <Column>
-          <SingleInputLine
-            label="Motor"
-            id="motor"
-            tooltip="The motors powering the system."
-          >
-            <MotorInput stateHook={[get.motor, set.setMotor]} />
-          </SingleInputLine>
-          <SingleInputLine
-            label="Efficiency (%)"
-            id="efficiency"
-            tooltip="The efficiency of the system in transmitting torque from the motors."
-          >
-            <NumberInput stateHook={[get.efficiency, set.setEfficiency]} />
-          </SingleInputLine>
+          <MotorSelector get={get} set={set} />
           <SingleInputLine
             label="Current Limit"
             id="currentLimit"
@@ -265,13 +253,6 @@ export default function FlywheelCalculator(): JSX.Element {
             <MeasurementInput
               stateHook={[get.currentLimit, set.setCurrentLimit]}
             />
-          </SingleInputLine>
-          <SingleInputLine
-            label="Shooter Ratio"
-            id="shooterRatio"
-            tooltip="The ratio between the motors and the shooter wheel(s)."
-          >
-            <RatioInput stateHook={[get.motorRatio, set.setMotorRatio]} />
           </SingleInputLine>
           <SingleInputLine
             label="Shooter Max Speed"

--- a/src/web/calculators/flywheel/converter.ts
+++ b/src/web/calculators/flywheel/converter.ts
@@ -17,7 +17,7 @@ export class FlywheelConverters {
       shooterWeight: s.weight,
       useCustomShooterMoi: s.useCustomMoi,
       motor: s.motor,
-      motorRatio: s.ratio,
+      ratio: s.ratio,
       currentLimit: FlywheelStateV2Defaults.currentLimit,
       flywheelRadius: FlywheelStateV2Defaults.flywheelRadius,
       flywheelMomentOfInertia: FlywheelStateV2Defaults.flywheelMomentOfInertia,

--- a/src/web/calculators/flywheel/index.ts
+++ b/src/web/calculators/flywheel/index.ts
@@ -54,7 +54,7 @@ export const FlywheelStateV2Defaults = {
 // export const FlywheelParamsV2 = Foo(FlywheelStateV2Defaults);
 export const FlywheelParamsV2 = {
   motor: withDefault(MotorParam, FlywheelStateV2Defaults.motor),
-  motorRatio: withDefault(RatioParam, FlywheelStateV2Defaults.motorRatio),
+  ratio: withDefault(RatioParam, FlywheelStateV2Defaults.motorRatio),
   efficiency: withDefault(NumberParam, FlywheelStateV2Defaults.efficiency),
   currentLimit: withDefault(
     MeasurementParam,

--- a/src/web/calculators/linear/components/LinearCalculator.tsx
+++ b/src/web/calculators/linear/components/LinearCalculator.tsx
@@ -5,12 +5,7 @@ import {
 } from "common/components/graphing/graphConfig";
 import SimpleHeading from "common/components/heading/SimpleHeading";
 import SingleInputLine from "common/components/io/inputs/SingleInputLine";
-import {
-  MeasurementInput,
-  MotorInput,
-  NumberInput,
-  RatioInput,
-} from "common/components/io/new/inputs";
+import { MeasurementInput } from "common/components/io/new/inputs";
 import MeasurementOutput from "common/components/io/outputs/MeasurementOutput";
 import { Column, Columns } from "common/components/styling/Building";
 import { useAsyncMemo } from "common/hooks/useAsyncMemo";
@@ -31,6 +26,7 @@ import {
   calculateUnloadedSpeed,
 } from "web/calculators/linear/linearMath";
 import KgKvKaDisplay from "web/calculators/shared/components/KgKvKaDisplay";
+import MotorSelector from "web/calculators/shared/components/MotorSelector";
 import {
   calculateKa,
   calculateKg,
@@ -176,27 +172,7 @@ export default function LinearCalculator(): JSX.Element {
 
       <Columns desktop>
         <Column>
-          <SingleInputLine
-            label="Motor"
-            id="motor"
-            tooltip="The motors powering the system."
-          >
-            <MotorInput stateHook={[get.motor, set.setMotor]} />
-          </SingleInputLine>
-          <SingleInputLine
-            label="Efficiency (%)"
-            id="efficiency"
-            tooltip="The efficiency of the system in transmitting torque from the motors."
-          >
-            <NumberInput stateHook={[get.efficiency, set.setEfficiency]} />
-          </SingleInputLine>
-          <SingleInputLine
-            label="Ratio"
-            id="ratio"
-            tooltip="The ratio between the motors and the system."
-          >
-            <RatioInput stateHook={[get.ratio, set.setRatio]} />
-          </SingleInputLine>
+          <MotorSelector get={get} set={set} />
           <SingleInputLine
             label="Travel Distance"
             id="comLength"

--- a/src/web/calculators/linear/index.ts
+++ b/src/web/calculators/linear/index.ts
@@ -26,6 +26,7 @@ export const LinearParamsV1 = {
   load: withDefault(MeasurementParam, new Measurement(120, "lb")),
   ratio: withDefault(RatioParam, new Ratio(2, RatioType.REDUCTION)),
   efficiency: withDefault(NumberParam, 100),
+  currentLimit: withDefault(MeasurementParam, new Measurement(40, "A"))
 };
 export type LinearStateV1 = Stateify<typeof LinearParamsV1>;
 

--- a/src/web/calculators/shared/components/MotorSelector.tsx
+++ b/src/web/calculators/shared/components/MotorSelector.tsx
@@ -1,0 +1,61 @@
+import SingleInputLine from "common/components/io/inputs/SingleInputLine";
+import {
+  MeasurementInput,
+  MotorInput,
+  NumberInput,
+  RatioInput,
+} from "common/components/io/new/inputs";
+import { BaseState, Setters } from "common/models/ExtraTypes";
+import Measurement from "common/models/Measurement";
+import Motor from "common/models/Motor";
+import Ratio from "common/models/Ratio";
+
+export interface MotorSelectorFields extends BaseState {
+  motor: Motor;
+  efficiency: number;
+  ratio: Ratio;
+  currentLimit: Measurement;
+}
+
+export interface MotorSelectorProps {
+  get: MotorSelectorFields;
+  set: Setters<MotorSelectorFields>;
+}
+
+export default function MotorSelector({
+  get,
+  set,
+}: MotorSelectorProps): JSX.Element {
+  return (
+    <>
+      <SingleInputLine
+        label="Motor"
+        id="motor"
+        tooltip="Motors powering the arm."
+      >
+        <MotorInput stateHook={[get.motor, set.setMotor]} />
+      </SingleInputLine>
+      <SingleInputLine
+        label="Efficiency (%)"
+        id="efficiency"
+        tooltip="The efficiency of the system in transmitting torque from the motors."
+      >
+        <NumberInput stateHook={[get.efficiency, set.setEfficiency]} />
+      </SingleInputLine>
+      <SingleInputLine
+        label="Ratio"
+        id="ratio"
+        tooltip="Ratio of the gearbox attached to the motor."
+      >
+        <RatioInput stateHook={[get.ratio, set.setRatio]} />
+      </SingleInputLine>
+      <SingleInputLine
+        label="Current Limit"
+        id="currentLimit"
+        tooltip="Current limit applied to each motor."
+      >
+        <MeasurementInput stateHook={[get.currentLimit, set.setCurrentLimit]} />
+      </SingleInputLine>
+    </>
+  );
+}


### PR DESCRIPTION
As a side-effect, `LinearCalculator` now has a current limit selector, though it is not yet implemented (need a suggestion on how you'd like to support it)