### PR TITLE
Fix calculation of speed after shot.

### DIFF
--- a/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
+++ b/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
@@ -127,25 +127,8 @@ export default function FlywheelCalculator(): JSX.Element {
   );
 
   const speedAfterShot = useMemo(
-    () =>
-      calculateSpeedAfterShot(
-        get.shooterMomentOfInertia.add(
-          get.flywheelMomentOfInertia.div(
-            get.flywheelRatio.asNumber() == 0
-              ? 1
-              : Math.pow(get.flywheelRatio.asNumber(), 2)
-          )
-        ),
-        flywheelEnergy,
-        projectileEnergy
-      ),
-    [
-      get.shooterMomentOfInertia,
-      get.flywheelMomentOfInertia,
-      get.flywheelRatio,
-      flywheelEnergy,
-      projectileEnergy,
-    ]
+    () => calculateSpeedAfterShot(projectileSpeed, get.shooterRadius),
+    [projectileSpeed, get.shooterRadius]
   );
 
   const totalMomentOfInertia = useMemo(

--- a/src/web/calculators/flywheel/flywheelMath.ts
+++ b/src/web/calculators/flywheel/flywheelMath.ts
@@ -106,24 +106,20 @@ export function calculateFlywheelEnergy(
 }
 
 export function calculateSpeedAfterShot(
-  totalMomentOfInertia: Measurement,
-  flywheelEnergy: Measurement,
-  projectileEnergy: Measurement
+  projectileVelocity: Measurement,
+  shooterWheelRadius: Measurement
 ): Measurement {
-  if (Measurement.anyAreZero(totalMomentOfInertia)) {
+  if (Measurement.anyAreZero(shooterWheelRadius)) {
     return new Measurement(0, "rpm");
   }
 
-  const v2 = flywheelEnergy
-    .sub(projectileEnergy)
-    .div(totalMomentOfInertia.mul(0.5))
-    .mul(new Measurement(1, "rad^2"))
-    .to("rpm^2");
+  const speed = projectileVelocity
+    .mul(2.0)
+    .div(shooterWheelRadius)
+    .mul(new Measurement(1, "rad"))
+    .to("rpm");
 
-  if (v2.lt(new Measurement(0, "rpm^2"))) {
-    return new Measurement(0, "rpm");
-  }
-  return new Measurement(Math.sqrt(v2.scalar), "rpm");
+  return speed;
 }
 
 export function calculateRecoveryTime(

--- a/src/web/calculators/flywheel/readme.md
+++ b/src/web/calculators/flywheel/readme.md
@@ -88,7 +88,7 @@ And now we have a fairly approachable formula that we can use!
 ### Other Math
 
 * $r_w$ = shooter wheel radius
-* $w_w$ = shooter wheel RPM
+* $\omega_w$ = shooter wheel rotational speed (radians/s)
 * $V_w$ = shooter wheel surface speed
 * $V_p$ = projectile speed
 * $T$ = speed transfer percentage
@@ -98,8 +98,8 @@ And now we have a fairly approachable formula that we can use!
 * $m_p$ = projectile weight
 
 $$ J_t = J_w + J_f $$
-$$ V_w = w_w * r_w $$
-$$ T = \frac{20 J_t}{7 m_p {\frac{r_w}{2}}^{2} + 40 J_t} $$
+$$ V_w = \omega_w * r_w $$
+$$ T = \frac{20 J_t}{7 m_p (2 {r_w})^{2} + 40 J_t} $$
 $$ V_p = V_w * T $$
 
 

--- a/src/web/calculators/flywheel/tests/flywheelMath.test.ts
+++ b/src/web/calculators/flywheel/tests/flywheelMath.test.ts
@@ -201,32 +201,25 @@ describe("flywheelMath", () => {
   );
   test.each([
     {
-      totalMomentOfInertia: in2lb(11),
-      flywheelEnergy: J(609.94),
-      projectileEnergy: J(67.37),
-      expected: rpm(5544.36),
+      projectileVelocity: fps(9.176),
+      shooterWheelRadius: inch(4),
+      expected: rpm(525.746072812),
     },
     {
-      totalMomentOfInertia: in2lb(7.5),
-      flywheelEnergy: J(415.87),
-      projectileEnergy: J(36.76),
-      expected: rpm(5612.699),
+      projectileVelocity: fps(18.0),
+      shooterWheelRadius: inch(4),
+      expected: rpm(1031.32403124),
     },
     {
-      totalMomentOfInertia: in2lb(5),
-      flywheelEnergy: J(128.3),
-      projectileEnergy: J(8.25),
-      expected: rpm(3868.262),
+      projectileVelocity: fps(9.176),
+      shooterWheelRadius: inch(2),
+      expected: rpm(1051.49214562),
     },
   ])(
     "%p calculateSpeedAfterShot",
-    ({ totalMomentOfInertia, flywheelEnergy, projectileEnergy, expected }) => {
+    ({ projectileVelocity, shooterWheelRadius, expected }) => {
       expect(
-        calculateSpeedAfterShot(
-          totalMomentOfInertia,
-          flywheelEnergy,
-          projectileEnergy
-        )
+        calculateSpeedAfterShot(projectileVelocity, shooterWheelRadius)
       ).toBeCloseToMeasurement(expected);
     }
   );


### PR DESCRIPTION
New calculation uses projectile speed and wheel radius.
Old calculation assumed all energy lost by the flywheel went to the
projectile, but substantial energy also goes to friction.