### PR TITLE
Fix MOI used in recovery, windup, and kA calcs.

### DIFF
--- a/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
+++ b/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
@@ -157,19 +157,20 @@ export default function FlywheelCalculator(): JSX.Element {
     }
 
     return calculateKa(
-      get.motor.stallTorque
-        .mul(get.motor.quantity)
-        .mul(get.motorRatio.asNumber())
-        .mul(get.efficiency / 100),
+      get.motor.stallTorque.mul(get.motor.quantity).mul(get.efficiency / 100),
       get.shooterRadius,
-      totalMomentOfInertia.div(get.flywheelRadius.mul(get.flywheelRadius))
+      totalMomentOfInertia.div(
+        get.shooterRadius
+          .mul(get.shooterRadius)
+          .mul(get.motorRatio.asNumber())
+          .mul(get.motorRatio.asNumber())
+      )
     );
   }, [
     get.motor.stallTorque,
     get.motor.quantity,
     get.motorRatio,
     get.efficiency,
-    get.flywheelRadius,
     totalMomentOfInertia,
     get.shooterRadius,
   ]);

--- a/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
+++ b/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
@@ -34,16 +34,24 @@ export default function FlywheelCalculator(): JSX.Element {
     FlywheelState.getState() as FlywheelStateV2
   );
 
+  const totalMomentOfInertia = useMemo(
+    () =>
+      get.motorRatio.asNumber() === 0
+        ? new Measurement(0, "in^2 * lbs")
+        : get.shooterMomentOfInertia.add(
+            get.flywheelMomentOfInertia.div(
+              get.flywheelRatio.asNumber() == 0
+                ? 1
+                : Math.pow(get.flywheelRatio.asNumber(), 2)
+            )
+          ),
+    [get.shooterMomentOfInertia, get.flywheelMomentOfInertia, get.flywheelRatio]
+  );
+
   const windupTime = useMemo(
     () =>
       calculateWindupTime(
-        get.shooterMomentOfInertia.add(
-          get.flywheelMomentOfInertia.div(
-            get.flywheelRatio.asNumber() == 0
-              ? 1
-              : Math.pow(get.flywheelRatio.asNumber(), 2)
-          )
-        ),
+        totalMomentOfInertia,
         get.motor,
         get.currentLimit,
         get.motorRatio,
@@ -54,9 +62,7 @@ export default function FlywheelCalculator(): JSX.Element {
       get.currentLimit,
       get.motorRatio,
       get.shooterTargetSpeed,
-      get.shooterMomentOfInertia,
-      get.flywheelMomentOfInertia,
-      get.flywheelRatio,
+      totalMomentOfInertia,
     ]
   );
 
@@ -82,21 +88,13 @@ export default function FlywheelCalculator(): JSX.Element {
       calculateProjectileExitVelocity(
         get.projectileWeight,
         get.shooterRadius,
-        get.shooterMomentOfInertia.add(
-          get.flywheelMomentOfInertia.div(
-            get.flywheelRatio.asNumber() == 0
-              ? 1
-              : Math.pow(get.flywheelRatio.asNumber(), 2)
-          )
-        ),
+        totalMomentOfInertia,
         shooterSurfaceSpeed
       ),
     [
       get.projectileWeight,
       get.shooterRadius,
-      get.shooterMomentOfInertia,
-      get.flywheelMomentOfInertia,
-      get.flywheelRatio,
+      totalMomentOfInertia,
       shooterSurfaceSpeed,
     ]
   );
@@ -107,59 +105,18 @@ export default function FlywheelCalculator(): JSX.Element {
   );
 
   const flywheelEnergy = useMemo(
-    () =>
-      calculateFlywheelEnergy(
-        get.shooterMomentOfInertia.add(
-          get.flywheelMomentOfInertia.div(
-            get.flywheelRatio.asNumber() == 0
-              ? 1
-              : Math.pow(get.flywheelRatio.asNumber(), 2)
-          )
-        ),
-        get.shooterTargetSpeed
-      ),
-    [
-      get.shooterMomentOfInertia,
-      get.flywheelMomentOfInertia,
-      get.flywheelRatio,
-      get.shooterTargetSpeed,
-    ]
+    () => calculateFlywheelEnergy(totalMomentOfInertia, get.shooterTargetSpeed),
+    [totalMomentOfInertia, get.shooterTargetSpeed]
   );
 
   const speedAfterShot = useMemo(
     () =>
       calculateSpeedAfterShot(
-        get.shooterMomentOfInertia.add(
-          get.flywheelMomentOfInertia.div(
-            get.flywheelRatio.asNumber() == 0
-              ? 1
-              : Math.pow(get.flywheelRatio.asNumber(), 2)
-          )
-        ),
+        totalMomentOfInertia,
         flywheelEnergy,
         projectileEnergy
       ),
-    [
-      get.shooterMomentOfInertia,
-      get.flywheelMomentOfInertia,
-      get.flywheelRatio,
-      flywheelEnergy,
-      projectileEnergy,
-    ]
-  );
-
-  const totalMomentOfInertia = useMemo(
-    () =>
-      get.motorRatio.asNumber() === 0
-        ? new Measurement(0, "in^2 * lbs")
-        : get.shooterMomentOfInertia.add(
-            get.flywheelMomentOfInertia.div(
-              get.flywheelRatio.asNumber() == 0
-                ? 1
-                : Math.pow(get.flywheelRatio.asNumber(), 2)
-            )
-          ),
-    [get.shooterMomentOfInertia, get.flywheelMomentOfInertia, get.flywheelRatio]
+    [totalMomentOfInertia, flywheelEnergy, projectileEnergy]
   );
 
   const recoveryTime = useMemo(

--- a/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
+++ b/src/web/calculators/flywheel/components/FlywheelCalculator.tsx
@@ -152,21 +152,14 @@ export default function FlywheelCalculator(): JSX.Element {
     () =>
       get.motorRatio.asNumber() === 0
         ? new Measurement(0, "in^2 * lbs")
-        : get.shooterMomentOfInertia
-            .add(
-              get.flywheelMomentOfInertia.div(
-                get.flywheelRatio.asNumber() == 0
-                  ? 1
-                  : Math.pow(get.flywheelRatio.asNumber(), 2)
-              )
+        : get.shooterMomentOfInertia.add(
+            get.flywheelMomentOfInertia.div(
+              get.flywheelRatio.asNumber() == 0
+                ? 1
+                : Math.pow(get.flywheelRatio.asNumber(), 2)
             )
-            .div(get.motorRatio.asNumber()),
-    [
-      get.shooterMomentOfInertia,
-      get.flywheelMomentOfInertia,
-      get.flywheelRatio,
-      get.motorRatio,
-    ]
+          ),
+    [get.shooterMomentOfInertia, get.flywheelMomentOfInertia, get.flywheelRatio]
   );
 
   const recoveryTime = useMemo(

--- a/src/web/calculators/flywheel/tests/flywheelMath.test.ts
+++ b/src/web/calculators/flywheel/tests/flywheelMath.test.ts
@@ -31,7 +31,7 @@ describe("flywheelMath", () => {
       currentLimit: A(50),
       ratio: new Ratio(2, RatioType.STEP_UP),
       targetSpeed: rpm(11000),
-      expected: s(3.282),
+      expected: s(6.564),
     },
     {
       momentOfInertia: in2lb(5),
@@ -39,7 +39,7 @@ describe("flywheelMath", () => {
       currentLimit: A(60),
       ratio: new Ratio(2, RatioType.REDUCTION),
       targetSpeed: rpm(9000),
-      expected: s(3.7047),
+      expected: s(1.85235),
     },
     {
       momentOfInertia: in2lb(13.1),
@@ -249,7 +249,7 @@ describe("flywheelMath", () => {
       targetSpeed: rpm(10000),
       speedAfterShot: rpm(9837.97),
       currentLimit: A(50),
-      expected: s(0.04739),
+      expected: s(0.09478),
     },
     {
       totalMomentOfInertia: in2lb(15),
@@ -259,7 +259,7 @@ describe("flywheelMath", () => {
       targetSpeed: rpm(3000),
       speedAfterShot: rpm(2967.68),
       currentLimit: A(60),
-      expected: s(0.00719),
+      expected: s(0.003595),
     },
   ])(
     "%p calculateRecoveryTime",


### PR DESCRIPTION
Specifically for recovery and windup time:
- Multiply torque by motor ratio. Note that doing this, combined with the existing division of the freespeed by the motor ratio, is equivalent to dividing the moi by the motor ratio squared.
- Update tests to reflect new expected results.
- Calculate windup time as recovery time from a speed of zero to eliminate duplication of calculation.
- Rename a couple variable for clarity.

Specifically for kA:
- Adjust MOI by the motor ratio squared to get MOI seen by motor.
- Divide that MOI by square of radius of shooter instead of flywheel since the surface acceleration of the shooter is  what the kA will be for.
- Don't multiply the motor torque by the motor ratio since that is now addressed by using the modified MOI.

Also remove duplicate calculations of total moi.