### PR TITLE
Fix Kraken X60 product page/free current

### DIFF
--- a/src/common/models/data/motors.json
+++ b/src/common/models/data/motors.json
@@ -50,16 +50,6 @@
     "url": "https://wcproducts.com/products/kraken"
   },
   {
-    "name": "Kraken X60 (FOC)",
-    "freeSpeed": { "magnitude": 5800, "unit": "rpm" },
-    "stallTorque": { "magnitude": 9.37, "unit": "N*m" },
-    "stallCurrent": { "magnitude": 483, "unit": "A" },
-    "freeCurrent": { "magnitude": 1.5, "unit": "A" },
-    "weight": { "magnitude": 1.2, "unit": "lbs" },
-    "diameter": { "magnitude": 2.37, "unit": "in" },
-    "url": "https://www.vexrobotics.com/217-6515.html"
-  },
-  {
     "name": "NEO Vortex",
     "freeSpeed": { "magnitude": 6784, "unit": "rpm" },
     "stallTorque": { "magnitude": 3.6, "unit": "N*m" },

--- a/src/common/models/data/motors.json
+++ b/src/common/models/data/motors.json
@@ -34,7 +34,17 @@
     "freeSpeed": { "magnitude": 6000, "unit": "rpm" },
     "stallTorque": { "magnitude": 7.09, "unit": "N*m" },
     "stallCurrent": { "magnitude": 366, "unit": "A" },
-    "freeCurrent": { "magnitude": 1.5, "unit": "A" },
+    "freeCurrent": { "magnitude": 2, "unit": "A" },
+    "weight": { "magnitude": 1.2, "unit": "lbs" },
+    "diameter": { "magnitude": 2.37, "unit": "in" },
+    "url": "https://www.vexrobotics.com/217-6515.html"
+  },
+  {
+    "name": "Kraken X60 (FOC)",
+    "freeSpeed": { "magnitude": 5800, "unit": "rpm" },
+    "stallTorque": { "magnitude": 9.37, "unit": "N*m" },
+    "stallCurrent": { "magnitude": 483, "unit": "A" },
+    "freeCurrent": { "magnitude": 2, "unit": "A" },
     "weight": { "magnitude": 1.2, "unit": "lbs" },
     "diameter": { "magnitude": 2.37, "unit": "in" },
     "url": "https://www.vexrobotics.com/217-6515.html"

--- a/src/common/models/data/motors.json
+++ b/src/common/models/data/motors.json
@@ -37,7 +37,7 @@
     "freeCurrent": { "magnitude": 2, "unit": "A" },
     "weight": { "magnitude": 1.2, "unit": "lbs" },
     "diameter": { "magnitude": 2.37, "unit": "in" },
-    "url": "https://www.vexrobotics.com/217-6515.html"
+    "url": "https://wcproducts.com/products/kraken"
   },
   {
     "name": "Kraken X60 (FOC)",
@@ -47,7 +47,7 @@
     "freeCurrent": { "magnitude": 2, "unit": "A" },
     "weight": { "magnitude": 1.2, "unit": "lbs" },
     "diameter": { "magnitude": 2.37, "unit": "in" },
-    "url": "https://www.vexrobotics.com/217-6515.html"
+    "url": "https://wcproducts.com/products/kraken"
   },
   {
     "name": "NEO Vortex",


### PR DESCRIPTION
The values used are pulled from motor curves at https://store.ctr-electronics.com/announcing-kraken-x60/.
It also looked like the non-FOC Kraken X60 free current did not match the documented value, so I updated it to match.

Thank you for all the work you guys do for the FIRST community!