### PR TITLE
Add VEX V5 Smart Motor (Red)

### DIFF
--- a/src/common/models/data/motors.json
+++ b/src/common/models/data/motors.json
@@ -178,5 +178,15 @@
     "weight": { "magnitude": 0.4375, "unit": "lbs" },
     "diameter": { "magnitude": 1.5, "unit": "in" },
     "url": "https://www.revrobotics.com/rev-41-1300/"
+  },
+  {
+    "name": "V5 Smart Motor (Red)",
+    "freeSpeed": { "magnitude": 100, "unit": "rpm" },
+    "stallTorque": { "magnitude": 2.1, "unit": "N*m" },
+    "stallCurrent": { "magnitude": 2.5, "unit": "A" },
+    "freeCurrent": { "magnitude": 0.9, "unit": "A" },
+    "weight": { "magnitude": 0.342, "unit": "lbs" },
+    "diameter": { "magnitude": 2.0, "unit": "in" },
+    "url": "https://www.vexrobotics.com/276-4840.html"
   }
 ]

--- a/src/web/info/motors/components/SpecTable.tsx
+++ b/src/web/info/motors/components/SpecTable.tsx
@@ -111,7 +111,7 @@ export default function SpecTable(): JSX.Element {
         inconsistent with other motors and are highly preliminary.
       </div>
       <div className="notification is-warning">
-        All motors except the Falcon, Kraken, and Vortex have 0.25 lbs added to
+        All motors except the Falcon, Kraken, Vortex, and V5 Smart Motor have 0.25 lbs added to
         their weight, representing an external motor controller.
       </div>
       <Table

--- a/src/web/info/motors/components/SpecTable.tsx
+++ b/src/web/info/motors/components/SpecTable.tsx
@@ -25,7 +25,7 @@ type MotorRow = {
 
 function adjustedWeight(motor: Motor): Measurement {
   return motor.weight.add(
-    ["Falcon 500", "Kraken X60", "Vortex"]
+    ["Falcon 500", "Kraken X60", "Vortex", "V5 Smart Motor"]
       .map((s) => motor.identifier.includes(s))
       .includes(true)
       ? lb(0)


### PR DESCRIPTION
Adds the [VEX V5 Smart Motor](https://www.vexrobotics.com/276-4840.html) with the red (100 RPM) gearbox. All the data was fetched from this stats sheet:  
https://kb.vex.com/hc/en-us/articles/360044325872-Understanding-V5-Smart-Motor-11W-Performance  
The reason red is used is because the stats sheet uses the red gearbox to measure stall torque.
Note: since the motor is rectangular, I averaged the length and height of the motor to get the "diameter" of the motor.

Although the V5 motor is not strictly FRC/FTC, I would like to use this tool to calculate values for VEX components as well.