### PR TITLE
Add angular feedforward to the flywheel calculator

### DIFF
--- a/src/web/calculators/flywheel/flywheelMath.ts
+++ b/src/web/calculators/flywheel/flywheelMath.ts
@@ -3,6 +3,15 @@ import Motor, { nominalVoltage } from "common/models/Motor";
 import Ratio from "common/models/Ratio";
 import { MotorRules } from "common/models/Rules";
 
+export function calculateVPerRps(motor: Motor, ratio: Ratio): Measurement {
+  if (motor.quantity === 0 || ratio.asNumber() === 0) {
+    return new Measurement(0, "V*s/rotation");
+  }
+
+  const maxShooterRps = motor.freeSpeed.div(ratio.asNumber()).to("rotation/s");
+  return nominalVoltage.div(maxShooterRps).to("V*s/rotation");
+}
+
 export function calculateWindupTime(
   momentOfInertia: Measurement,
   motor: Motor,

--- a/src/web/calculators/shared/components/FeedforwardAnalysis.tsx
+++ b/src/web/calculators/shared/components/FeedforwardAnalysis.tsx
@@ -9,6 +9,8 @@ export interface FeedforwardAnalysisProps {
   kA: Measurement;
   distanceType: "linear" | "angular";
   kG?: Measurement;
+  kVAlt?: Measurement;
+  kAAlt?: Measurement;
 }
 
 const FeedforwardAnalysis: React.FC<FeedforwardAnalysisProps> = ({
@@ -16,6 +18,8 @@ const FeedforwardAnalysis: React.FC<FeedforwardAnalysisProps> = ({
   kV,
   kA,
   distanceType,
+  kVAlt,
+  kAAlt,
 }) => {
   return (
     <div>
@@ -44,6 +48,19 @@ const FeedforwardAnalysis: React.FC<FeedforwardAnalysisProps> = ({
           defaultUnit={distanceType === "angular" ? "V*s/rotation" : "V*s/m"}
         />
       </SingleInputLine>
+      {kVAlt !== undefined && (
+        <SingleInputLine
+          label="kV (angular)"
+          id="kVAlt"
+          tooltip="Velocity feedforward gain in angular units. Use this for RPM-based velocity control."
+        >
+          <MeasurementOutput
+            stateHook={[kVAlt, () => undefined]}
+            numberRoundTo={4}
+            defaultUnit="V*s/rotation"
+          />
+        </SingleInputLine>
+      )}
       <SingleInputLine
         label="kA"
         id="kA"
@@ -57,6 +74,19 @@ const FeedforwardAnalysis: React.FC<FeedforwardAnalysisProps> = ({
           }
         />
       </SingleInputLine>
+      {kAAlt !== undefined && (
+        <SingleInputLine
+          label="kA (angular)"
+          id="kAAlt"
+          tooltip="Acceleration feedforward gain in angular units. Use this for RPM-based velocity control."
+        >
+          <MeasurementOutput
+            stateHook={[kAAlt, () => undefined]}
+            numberRoundTo={4}
+            defaultUnit="V*s^2/rotation"
+          />
+        </SingleInputLine>
+      )}
       <SingleInputLine
         label="System Response Time"
         id="systemResponseTime"

--- a/src/web/calculators/shared/components/VelocityControlGainsAnalysis.tsx
+++ b/src/web/calculators/shared/components/VelocityControlGainsAnalysis.tsx
@@ -9,11 +9,13 @@ interface VelocityControlGainsAnalysisProps {
   ka: Measurement;
   dt?: Measurement;
   velTolerance?: Measurement;
+  kVAlt?: Measurement;
+  kAAlt?: Measurement;
 }
 
 const VelocityControlGainsAnalysis: React.FC<
   VelocityControlGainsAnalysisProps
-> = ({ kv, ka, dt, velTolerance }) => {
+> = ({ kv, ka, dt, velTolerance, kVAlt, kAAlt }) => {
   return (
     <div>
       <Divider color="primary">Estimated Control Gains</Divider>
@@ -23,7 +25,13 @@ const VelocityControlGainsAnalysis: React.FC<
         particular attention to units. Always be careful the first time you
         enable closed-loop control of a mechanism.
       </Message>
-      <FeedforwardAnalysis kV={kv} kA={ka} distanceType={"linear"} />
+      <FeedforwardAnalysis
+        kV={kv}
+        kA={ka}
+        distanceType={"linear"}
+        kVAlt={kVAlt}
+        kAAlt={kAAlt}
+      />
       <VelocityFeedbackAnalysis
         kv={kv}
         ka={ka}


### PR DESCRIPTION
Reference implementation/closing #2064 

Minimal change, added a seperate kV (angular) and kA (angular). I considered adding them to the dropdown, but this would require additional changes to Measurements which is probably overscoped for a minimal change to the flywheel system.