### PR TITLE
Account for Equivalent Resistance in Multi-Motor Linear Mechanisms

### DIFF
--- a/app/lib/math/__snapshots__/linear.fuzz.test.ts.snap
+++ b/app/lib/math/__snapshots__/linear.fuzz.test.ts.snap
@@ -115,9 +115,9 @@ exports[`linear formula fuzz cases > produces stable guessed limits across reali
       "velocityMps": 2.510064,
     },
     {
-      "accelerationMps2": 174.6739,
+      "accelerationMps2": 179.5622,
       "name": "kraken-x60-2 load=1 spool=0.5 ratio=1 stator=100 supply=60 angle=90 efficiency=50 cascade=false",
-      "velocityMps": 3.483588,
+      "velocityMps": 3.479125,
     },
     {
       "accelerationMps2": 1926.031,
@@ -127,12 +127,12 @@ exports[`linear formula fuzz cases > produces stable guessed limits across reali
     {
       "accelerationMps2": 88.09661,
       "name": "kraken-x60-2 load=1 spool=2 ratio=1 stator=60 supply=60 angle=-90 efficiency=50 cascade=false",
-      "velocityMps": 15.08796,
+      "velocityMps": 14.85876,
     },
     {
-      "accelerationMps2": 172.197,
+      "accelerationMps2": 179.7136,
       "name": "kraken-x60-2 load=1 spool=2 ratio=4 stator=100 supply=20 angle=45 efficiency=90 cascade=true",
-      "velocityMps": 3.471308,
+      "velocityMps": 3.463826,
     },
     {
       "accelerationMps2": 8.91681,
@@ -142,22 +142,22 @@ exports[`linear formula fuzz cases > produces stable guessed limits across reali
     {
       "accelerationMps2": 24.2552,
       "name": "kraken-x60-2 load=1 spool=6 ratio=4 stator=20 supply=60 angle=90 efficiency=90 cascade=true",
-      "velocityMps": 10.68566,
+      "velocityMps": 10.82891,
     },
     {
       "accelerationMps2": 529.4611,
       "name": "kraken-x60-2 load=1 spool=6 ratio=20 stator=60 supply=60 angle=45 efficiency=50 cascade=false",
-      "velocityMps": 2.187139,
+      "velocityMps": 2.190786,
     },
     {
-      "accelerationMps2": 55.83438,
+      "accelerationMps2": 55.49352,
       "name": "kraken-x60-2 load=10 spool=0.5 ratio=1 stator=100 supply=60 angle=-90 efficiency=90 cascade=true",
-      "velocityMps": 3.250158,
+      "velocityMps": 3.253616,
     },
     {
       "accelerationMps2": 206.1581,
       "name": "kraken-x60-2 load=10 spool=0.5 ratio=20 stator=20 supply=20 angle=90 efficiency=50 cascade=false",
-      "velocityMps": 0.1821531,
+      "velocityMps": 0.1825113,
     },
     {
       "accelerationMps2": 7.222616,
@@ -165,14 +165,14 @@ exports[`linear formula fuzz cases > produces stable guessed limits across reali
       "velocityMps": 14.62955,
     },
     {
-      "accelerationMps2": 36.0597,
+      "accelerationMps2": 37.11001,
       "name": "kraken-x60-2 load=10 spool=2 ratio=4 stator=100 supply=20 angle=-90 efficiency=50 cascade=false",
-      "velocityMps": 3.470627,
+      "velocityMps": 3.458583,
     },
     {
-      "accelerationMps2": 235.2064,
+      "accelerationMps2": 35.83176,
       "name": "kraken-x60-2 load=10 spool=2 ratio=20 stator=100 supply=60 angle=45 efficiency=90 cascade=true",
-      "velocityMps": 0.7224735,
+      "velocityMps": 0.712436,
     },
     {
       "accelerationMps2": 3.566724,
@@ -180,19 +180,19 @@ exports[`linear formula fuzz cases > produces stable guessed limits across reali
       "velocityMps": 10.97216,
     },
     {
-      "accelerationMps2": 14.95681,
+      "accelerationMps2": 16.4681,
       "name": "kraken-x60-2 load=10 spool=6 ratio=20 stator=60 supply=20 angle=90 efficiency=90 cascade=true",
-      "velocityMps": 2.07463,
+      "velocityMps": 2.073017,
     },
     {
-      "accelerationMps2": 0.3571325,
+      "accelerationMps2": 1.366261,
       "name": "kraken-x60-2 load=50 spool=0.5 ratio=1 stator=100 supply=20 angle=45 efficiency=50 cascade=false",
-      "velocityMps": 0.3213409,
+      "velocityMps": 0.6873611,
     },
     {
       "accelerationMps2": 46.36594,
       "name": "kraken-x60-2 load=50 spool=0.5 ratio=20 stator=20 supply=20 angle=-90 efficiency=90 cascade=true",
-      "velocityMps": 0.1868486,
+      "velocityMps": 0.184859,
     },
     {
       "accelerationMps2": 0.1,
@@ -207,7 +207,7 @@ exports[`linear formula fuzz cases > produces stable guessed limits across reali
     {
       "accelerationMps2": 15.69064,
       "name": "kraken-x60-2 load=50 spool=2 ratio=20 stator=100 supply=60 angle=-90 efficiency=50 cascade=false",
-      "velocityMps": 0.7887789,
+      "velocityMps": 0.7601282,
     },
     {
       "accelerationMps2": 0.1,
@@ -215,9 +215,9 @@ exports[`linear formula fuzz cases > produces stable guessed limits across reali
       "velocityMps": 0.1,
     },
     {
-      "accelerationMps2": 6.798159,
+      "accelerationMps2": 7.144154,
       "name": "kraken-x60-2 load=50 spool=6 ratio=20 stator=60 supply=20 angle=0 efficiency=50 cascade=false",
-      "velocityMps": 2.079225,
+      "velocityMps": 2.073739,
     },
     {
       "accelerationMps2": 114.7488,

--- a/app/lib/math/linear.test.ts
+++ b/app/lib/math/linear.test.ts
@@ -264,6 +264,40 @@ describe('calculateGuessedLimits', () => {
     expect(a_max_guessed.to('m/s^2').scalar).toBeGreaterThan(1);
   });
 
+  it('shares gravity holding current across parallel motors when estimating velocity', () => {
+    const { v_max_guessed } = calculateGuessedLimits(
+      Motor.KrakenX60sFOC(4),
+      new Ratio(4, RatioType.REDUCTION),
+      new Measurement(15, 'lb'),
+      new Measurement(1.5, 'in'),
+      new Measurement(80, 'A'),
+      new Measurement(60, 'A'),
+      new Measurement(12, 'V'),
+      new Measurement(90, 'deg'),
+      100,
+      false,
+    );
+
+    expect(v_max_guessed.to('m/s').scalar).toBeCloseTo(2.593352, 6);
+  });
+
+  it('returns zero guessed velocity when there are no motors', () => {
+    const { v_max_guessed } = calculateGuessedLimits(
+      Motor.KrakenX60sFOC(0),
+      new Ratio(4, RatioType.REDUCTION),
+      new Measurement(15, 'lb'),
+      new Measurement(1.5, 'in'),
+      new Measurement(80, 'A'),
+      new Measurement(60, 'A'),
+      new Measurement(12, 'V'),
+      new Measurement(90, 'deg'),
+      100,
+      false,
+    );
+
+    expect(v_max_guessed.to('m/s').scalar).toBe(0);
+  });
+
   it('never returns the 0.1 floor for a reasonable mechanism', () => {
     const motor = Motor.KrakenX60sFOC(2);
     const ratio = new Ratio(2, RatioType.REDUCTION);
@@ -501,6 +535,24 @@ describe('calculateGuessedLimits', () => {
     );
   });
 
+  it('uses parallel resistance when supply power limits acceleration', () => {
+    const guessedAccelerationFor = (quantity: number) =>
+      calculateGuessedLimits(
+        Motor.KrakenX60sFOC(quantity),
+        new Ratio(2, RatioType.REDUCTION),
+        new Measurement(5 * quantity, 'lb'),
+        new Measurement(1, 'in'),
+        new Measurement(1000, 'A'),
+        new Measurement(1, 'A'),
+        new Measurement(12, 'V'),
+        new Measurement(0, 'deg'),
+        100,
+        false,
+      ).a_max_guessed.to('m/s^2').scalar;
+
+    expect(guessedAccelerationFor(4)).toBeCloseTo(guessedAccelerationFor(1), 6);
+  });
+
   const GRAVITY_MPS2 = 9.80665;
 
   function peakSupplyWatts(
@@ -555,6 +607,39 @@ describe('calculateGuessedLimits', () => {
         travelMeters,
       ),
     ).toBeLessThan(2 * budget);
+  });
+
+  it('uses parallel resistance in a distance-aware supply-limited profile', () => {
+    const guessedProfileFor = (quantity: number) => {
+      const result = calculateGuessedLimits(
+        Motor.KrakenX60sFOC(quantity),
+        new Ratio(1.75, RatioType.REDUCTION),
+        new Measurement(5 * quantity, 'lb'),
+        new Measurement(1, 'in'),
+        new Measurement(50, 'A'),
+        new Measurement(10, 'A'),
+        new Measurement(12, 'V'),
+        new Measurement(90, 'deg'),
+        100,
+        false,
+        new Measurement(12, 'V'),
+        new Measurement(60, 'in'),
+      );
+
+      return {
+        accelerationMPS2: result.a_max_guessed.to('m/s^2').scalar,
+        velocityMPS: result.v_max_guessed.to('m/s').scalar,
+      };
+    };
+
+    const oneMotor = guessedProfileFor(1);
+    const fourMotors = guessedProfileFor(4);
+
+    expect(fourMotors.velocityMPS).toBeCloseTo(oneMotor.velocityMPS, 6);
+    expect(fourMotors.accelerationMPS2).toBeCloseTo(
+      oneMotor.accelerationMPS2,
+      6,
+    );
   });
 
   it('leaves an already-feasible profile untouched when given a distance', () => {

--- a/app/lib/math/linear.test.ts
+++ b/app/lib/math/linear.test.ts
@@ -264,21 +264,22 @@ describe('calculateGuessedLimits', () => {
     expect(a_max_guessed.to('m/s^2').scalar).toBeGreaterThan(1);
   });
 
-  it('shares gravity holding current across parallel motors when estimating velocity', () => {
-    const { v_max_guessed } = calculateGuessedLimits(
-      Motor.KrakenX60sFOC(4),
-      new Ratio(4, RatioType.REDUCTION),
-      new Measurement(15, 'lb'),
-      new Measurement(1.5, 'in'),
-      new Measurement(80, 'A'),
-      new Measurement(60, 'A'),
-      new Measurement(12, 'V'),
-      new Measurement(90, 'deg'),
-      100,
-      false,
-    );
+  it('estimates a higher gravity-limited velocity with more parallel motors', () => {
+    const guessedVelocityFor = (quantity: number) =>
+      calculateGuessedLimits(
+        Motor.KrakenX60sFOC(quantity),
+        new Ratio(4, RatioType.REDUCTION),
+        new Measurement(15, 'lb'),
+        new Measurement(1.5, 'in'),
+        new Measurement(80, 'A'),
+        new Measurement(60, 'A'),
+        new Measurement(12, 'V'),
+        new Measurement(90, 'deg'),
+        100,
+        false,
+      ).v_max_guessed.to('m/s').scalar;
 
-    expect(v_max_guessed.to('m/s').scalar).toBeCloseTo(2.593352, 6);
+    expect(guessedVelocityFor(4)).toBeGreaterThan(guessedVelocityFor(1));
   });
 
   it('returns zero guessed velocity when there are no motors', () => {

--- a/app/lib/math/linear.ts
+++ b/app/lib/math/linear.ts
@@ -49,7 +49,13 @@ export function calculateGuessedLimits(
   travelDistance: Measurement | null = null,
 ) {
   if (
-    Measurement.anyAreZero(spoolDiameter, ratio.asNumber(), load, efficiency)
+    Measurement.anyAreZero(
+      spoolDiameter,
+      ratio.asNumber(),
+      load,
+      efficiency,
+      motor.quantity,
+    )
   ) {
     return {
       v_max_guessed: new Measurement(0, 'm/s'),
@@ -71,6 +77,7 @@ export function calculateGuessedLimits(
   const voltage = motor.voltage;
 
   const R_motor = voltage.div(stallCurrent);
+  const R_equivalent = R_motor.div(motor.quantity);
   const Kt = motor.kT;
   const Kv = motor.kV;
 
@@ -78,7 +85,7 @@ export function calculateGuessedLimits(
   // At stall: Pin = Pout => V_batt * I_supply = I_stator^2 * R
   const I_supply_limit = supplyLimit.mul(motor.quantity);
   const powerLimit = supplyVoltage.mul(I_supply_limit);
-  const I_stator_max_from_supply_sq = powerLimit.div(R_motor);
+  const I_stator_max_from_supply_sq = powerLimit.div(R_equivalent);
   const I_stator_max_from_supply = new Measurement(
     Math.sqrt(Math.max(0, I_stator_max_from_supply_sq.to('A^2').scalar)),
     'A',
@@ -102,13 +109,14 @@ export function calculateGuessedLimits(
   // 2. Max Velocity (Voltage, Supply, or Control Effort Limited)
   // Holding current needed to fight gravity at steady state (a=0)
   const I_gravity = F_gravity.div(Kt.mul(G).mul(eta).div(r));
+  const V_resistance_drop = I_gravity.mul(R_equivalent);
 
   // Velocity is limited by Back-EMF (V_emf).
-  const V_emf_voltage_limited = supplyVoltage.sub(I_gravity.mul(R_motor));
+  const V_emf_voltage_limited = supplyVoltage.sub(V_resistance_drop);
   const V_emf_supply_limited = powerLimit
     .div(Measurement.max(new Measurement(0.01, 'A'), I_gravity))
-    .sub(I_gravity.mul(R_motor));
-  const V_emf_rVolts_limited = rVolts.sub(I_gravity.mul(R_motor));
+    .sub(V_resistance_drop);
+  const V_emf_rVolts_limited = rVolts.sub(V_resistance_drop);
 
   const V_emf_max = Measurement.min(
     Measurement.min(
@@ -136,8 +144,7 @@ export function calculateGuessedLimits(
     guessAccelMPS2: a_max_guessed.to('m/s^2').scalar,
     massKg: m.to('kg').scalar,
     gravityForceN: F_gravity.to('N').scalar,
-    resistanceOhms: R_motor.to('Ohm').scalar,
-    motorQuantity: motor.quantity,
+    equivalentResistanceOhms: R_equivalent.to('Ohm').scalar,
     statorLimitAmps: I_stator_limit.to('A').scalar,
     supplyPowerWatts: powerLimit.to('W').scalar,
     controlVolts: rVolts.to('V').scalar,
@@ -170,8 +177,7 @@ interface PowerFeasibleInput {
   guessAccelMPS2: number;
   massKg: number;
   gravityForceN: number;
-  resistanceOhms: number;
-  motorQuantity: number;
+  equivalentResistanceOhms: number;
   statorLimitAmps: number;
   supplyPowerWatts: number;
   controlVolts: number;
@@ -197,12 +203,11 @@ function powerFeasibleProfile(
       (-backEmfVolts +
         Math.sqrt(
           backEmfVolts * backEmfVolts +
-            4 * i.resistanceOhms * i.supplyPowerWatts,
+            4 * i.equivalentResistanceOhms * i.supplyPowerWatts,
         )) /
-      (2 * i.resistanceOhms);
+      (2 * i.equivalentResistanceOhms);
     const voltageLimitedAmps =
-      (Math.max(0, i.controlVolts - backEmfVolts) / i.resistanceOhms) *
-      i.motorQuantity;
+      Math.max(0, i.controlVolts - backEmfVolts) / i.equivalentResistanceOhms;
     const effectiveAmps = Math.min(
       i.statorLimitAmps,
       supplyLimitedAmps,

--- a/playwright-tests/linear.spec.ts-snapshots/motor-magnitude-changed-Google-Chrome-linux.yaml
+++ b/playwright-tests/linear.spec.ts-snapshots/motor-magnitude-changed-Google-Chrome-linux.yaml
@@ -41,7 +41,7 @@
 - combobox: Ohm
 - text: Max Velocity
 - switch "Custom"
-- text: Custom Guessed 135.235
+- text: Custom Guessed 136.262
 - combobox: in/s
 - text: Max Acceleration
 - switch "Custom"
@@ -50,11 +50,11 @@
 - button "LQR Tuning":
   - img
   - heading "LQR Tuning" [level=2]
-- text: Time to Goal 0.464
+- text: Time to Goal 0.461
 - combobox: s
 - text: Stall Load 107.307
 - combobox: lbs
-- text: End Error 0.005
+- text: End Error 0.006
 - combobox: in
 - heading "Simulation" [level=2]
 - list:
@@ -73,7 +73,7 @@
   - listitem:
     - img "Velocity (in/s) legend icon"
     - text: Velocity (in/s)
-- application: 0.0351 0.0821 0.12 0.15 0.183 0.221 0.261 0.301 0.341 0.381 0.422 0.464 Time (s) -140 -70 0 70 140 Velocity (in/s) / Current (A) 0 15 30 45 60 Position (in)
+- application: 0.0361 0.0821 0.12 0.15 0.183 0.221 0.261 0.301 0.341 0.381 0.421 0.461 Time (s) -140 -70 0 70 140 Velocity (in/s) / Current (A) 0 15 30 45 60 Position (in)
 - text: kA 0.009
 - combobox: V*s^2/m
 - text: kV 3.097


### PR DESCRIPTION
I noticed in writing #2282 that the linear mechanism models multi-motor mechanisms uses total current, but operates on that current with the resistance of a single motor. This leads to wrong results for calculations like the required current to resist gravity in the steady state velocity estimate, the supply-power limit, and distance-aware trajectory calculation. The gravity mistake is especially noticeable for mechanisms powered by v5 smart motors, as vexu mechanisms use many lower powered motors as opposed to frc's fewer higher powered motors. The error also affects FRC motors, the magnitude is just less noticeable.

I made a few tests that prove the issue:
- a linear mechanism with 1 and 4 motors shouldn't have the same steady-state velocity estimate, since gravity load is shared across the 4 motors.
- The acceleration limit for 1 motor lifting 5 pounds should be the same as 4 motors lifting 20 pounds (this is the acceleration analog to the previous case)
- A supply-limited trajectory for 1 motor lifting 5 pounds should have the same velocity and acceleration as 4 motors lifting 20 pounds (previously 4 motors would fare worse).

The fix is to instead use the equivalent resistance of the group of motors in parallel when operating with a total current, which is R / N motors. This leads to all of the previous tests working as expected.

Additionally, since we are dividing by the number of motors, I added logic and a test to give 0 velocity and acceleration for a mechanism with 0 motors.

This changes the results of many of the fuzz tests by a small margin. The one with an alarming change is "kraken-x60-2 load=10 spool=2 ratio=4 stator=100 supply=20 angle=-90 efficiency=50 cascade=false", which crosses the feasibility threshold with increased velocity and drops the acceleration guess from 235 m/s^2 (which feels really high) to 35 m/s^2. The total trajectory time and velocity are still comparable.